### PR TITLE
change filter to enable graphql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public/assets
 /vendor
 /bee-gorm-graphql
 /tmp
+*.exe

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/assets
 /bee-gorm-graphql
 /tmp
 *.exe
+*.exe~

--- a/routers/filters.go
+++ b/routers/filters.go
@@ -1,18 +1,18 @@
 package routers
 
 import (
-  "strings"
-  "github.com/astaxie/beego/context"
+	"strings"
+
+	"github.com/astaxie/beego/context"
 )
 
 var filterLoggedInUser = func(ctx *context.Context) {
-  url := ctx.Input.URL()
-  if strings.HasPrefix(url, "/session") || strings.HasPrefix(url, "/graphql"){
-    return
-  }
-  _, ok := ctx.Input.Session("current_user").(map[string]string)
-  if !ok {
-    ctx.Redirect(302, "/session/login")
-  }
+	url := ctx.Input.URL()
+	if strings.HasPrefix(url, "/session") || strings.HasPrefix(url, "/graphql") || strings.HasPrefix(url, "/query") {
+		return
+	}
+	_, ok := ctx.Input.Session("current_user").(map[string]string)
+	if !ok {
+		ctx.Redirect(302, "/session/login")
+	}
 }
-


### PR DESCRIPTION
graphql use the 'query' url,but the 'query' url is not excluded in the filter,so the graphql page is not able to use.
I add the 'query' url to the excluded urls in the filter.^_^